### PR TITLE
Consider adding sendspin

### DIFF
--- a/.env
+++ b/.env
@@ -19,7 +19,7 @@ DOCKER_LOCALHOST="host.docker.internal"
 # MQTT_TOPIC=shairport/dev/boombox
 
 
-SHAIRPORT_SYNC_TAG=pr-15
+SHAIRPORT_SYNC_TAG=1.1.0
 
 
 LIBRESPOT_TAG=bookworm-2026-03-14

--- a/.env
+++ b/.env
@@ -19,7 +19,7 @@ DOCKER_LOCALHOST="host.docker.internal"
 # MQTT_TOPIC=shairport/dev/boombox
 
 
-SHAIRPORT_SYNC_TAG=1.0.3
+SHAIRPORT_SYNC_TAG=pr-15
 
 
 LIBRESPOT_TAG=bookworm-2026-03-14

--- a/.env
+++ b/.env
@@ -19,7 +19,7 @@ DOCKER_LOCALHOST="host.docker.internal"
 # MQTT_TOPIC=shairport/dev/boombox
 
 
-SHAIRPORT_SYNC_TAG=pr-16
+SHAIRPORT_SYNC_TAG=1.1.1
 
 
 LIBRESPOT_TAG=bookworm-2026-03-14

--- a/.env
+++ b/.env
@@ -19,7 +19,7 @@ DOCKER_LOCALHOST="host.docker.internal"
 # MQTT_TOPIC=shairport/dev/boombox
 
 
-SHAIRPORT_SYNC_TAG=1.1.0
+SHAIRPORT_SYNC_TAG=pr-16
 
 
 LIBRESPOT_TAG=bookworm-2026-03-14

--- a/notes/SENDSPIN.md
+++ b/notes/SENDSPIN.md
@@ -1,0 +1,3 @@
+# Sendspin
+
+I should consider adding this.

--- a/scripts/pi/docker_install.sh
+++ b/scripts/pi/docker_install.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-NUMBER_STEPS=5
+NUMBER_STEPS=4
 
 echo "Install docker in ${NUMBER_STEPS} steps!"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only an AirPlay container image tag bump and a notes file; no auth, data, or new services wired in.
> 
> **Overview**
> Bumps the **Shairport Sync** Docker image pin from `1.0.3` to `1.1.1` via `SHAIRPORT_SYNC_TAG` in `.env`, so `docker-compose` will use `ghcr.io/jzucker2/simple-shairport-sync:1.1.1` on the next deploy.
> 
> Adds `notes/SENDSPIN.md` as a placeholder to **consider adding Sendspin** later—no runtime or compose changes for that yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f16320a48bbb31ef29752f59915dd4ec5e080ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->